### PR TITLE
Create and map input signals using Busses

### DIFF
--- a/sc/HelpSource/Classes/Mapper.schelp
+++ b/sc/HelpSource/Classes/Mapper.schelp
@@ -3,7 +3,7 @@ summary:: UGen for using libmapper with SuperCollider server
 categories:: UGens>Synth control
 
 DESCRIPTION::
-Creates a libmapper devices on the SuperCollider server. Input and output signals can be created with the MapIn and MapOut. The signals stay active util the libmapper device is destroyed either by rebooting the server or calling Mapper.disable.
+Creates a libmapper devices on the SuperCollider server. Input and output signals can be created with the MapIn and MapOut, or a mappable Bus can be created for a signal with Mapper.makeInSignalBus(). The signals stay active util the libmapper device is destroyed either by rebooting the server or calling Mapper.disable.
 
 CLASSMETHODS::
 private:: categories
@@ -32,5 +32,15 @@ s.waitForBoot({
 {
     RLPF.ar(Saw.ar(50), MapIn.kr(\ffreq, 20, 20000), 0.2).dup * 0.2;
 }.play
+)
+
+// Or, use makeInSignalBus to map a Bus directly to a Synth argument
+(
+SynthDef(\SineGenerator, { |out=0, freq=200, gain=0|
+    Out.ar( out, SinOsc.ar(freq, 0, gain) )
+}).add;
+a = Synth(\SineGenerator);
+var freqBus = Mapper.makeInSignalBus(s, "frequency", 10, 10000);
+a.map(\freq, freqBus);
 )
 ::

--- a/sc/classes/Mapper.sc
+++ b/sc/classes/Mapper.sc
@@ -12,6 +12,13 @@ Mapper : UGen {
             FreeSelf.kr(Impulse.kr(1));
         }
     }
+
+    *makeInSignalBus {
+        arg server, name, min, max;
+        var bus = Bus.control(server);
+        {Out.kr(bus.index, MapIn.kr(name, min, max))}.play;
+        ^bus;
+    }
 }
 
 MapIn : UGen {


### PR DESCRIPTION
- Adds a function that creates an input signal and returns a corresponding Bus that can be mapped to Synth arguments
- This function is a good fit for mapping with premade SynthDef libraries where a MapIn can't/shouldn't be added inside the definition
- Still pondering how to make something like this work for output signals, any ideas would be helpful (I'm pretty new to SC)

Example: 
```
(
SynthDef(\SineGenerator, { |out=0, freq=200, gain=0|
    Out.ar( out, SinOsc.ar(freq, 0, gain) )
}).add;
a = Synth(\SineGenerator);
var freqBus = Mapper.makeInSignalBus(s, "frequency", 10, 10000);
a.map(\freq, freqBus);
)
```